### PR TITLE
Add pre-push hook that runs Python & kdb unit tests

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,28 @@
+### Repository ###
+This is a personal repository, belonging to Tay Cong Run, to store 
+solutions to code challenges that are sourced from various platforms 
+(e.g. HackerRank, Advent of Code, etc). They can be freely referenced
+by anyone for educational purposes.
+
+### Directory Structure ###
+kdb (Coding challenge solutions in kdb)
+  aoc_2023 (Advent of Code 2023)
+  unit_tests (All k4unit test cases & files)
+    aoc_2023
+python (Coding challenge solutions in Python)
+  hackerrank (Hacker Rank Challenges)
+  unit_tests (All Python unittest cases)
+
+### Unit Testing ###
+kdb
+  Unit testing for kdb uses the k4unit framework. To be exact, it is a
+  forked repository of the vanilla k4unit that is embedded into this
+  repository as a git submodule. The forked k4unit additionally supports
+  test discovery and command-line arguments. To begin, run the
+  coding_challenges/kdb/unit_tests/k4unit/k4unit.q file from anywhere.
+
+Python
+  Unit testing for Python uses the unittest framework. The directory
+  structure and test files have been written to work with VSCode Python
+  Extension. See https://code.visualstudio.com/docs/python/testing.
+

--- a/README.txt
+++ b/README.txt
@@ -5,6 +5,7 @@ solutions to code challenges that are sourced from various platforms
 by anyone for educational purposes.
 
 ### Directory Structure ###
+hooks (Git hooks)
 kdb (Coding challenge solutions in kdb)
   aoc_2023 (Advent of Code 2023)
   unit_tests (All k4unit test cases & files)
@@ -26,3 +27,6 @@ Python
   structure and test files have been written to work with VSCode Python
   Extension. See https://code.visualstudio.com/docs/python/testing.
 
+Unit tests can be integrated into Git workflow, specifically in the
+pre-push stage. To use this, copy the files in coding_challenges/hooks/
+into coding_challenges/.git/hooks/.

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+#
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+
+while read local_ref local_oid remote_ref remote_oid
+do
+	if test "$local_oid" = "$zero"
+	then
+		# Handle delete
+		:
+	else
+		if test "$remote_oid" = "$zero"
+		then
+			# New branch, examine all commits
+			range="$local_oid"
+		else
+			# Update to existing branch, examine new commits
+			range="$remote_oid..$local_oid"
+		fi
+
+		# Check for WIP commit
+		commit=$(git rev-list -n 1 --grep '^WIP' "$range")
+		if test -n "$commit"
+		then
+			echo >&2 "Found WIP commit in $local_ref, not pushing"
+			exit 1
+		fi
+
+	fi
+done
+
+# Run Python unit tests
+python -m unittest discover -s $PWD/python
+punit=$?
+if test $punit -eq 1
+then echo "WARN: Python unit tests failed"
+fi
+
+# Run kdb unit tests
+q $PWD/kdb/unit_tests/k4unit/k4unit.q -savefile :$PWD/kdb/unit_tests/results.csv -dirs :$PWD/kdb/unit_tests -patterns test_*.csv -exit 1
+kunit=$?
+if test $kunit -eq 1
+then echo "WARN: kdb unit tests failed"
+fi
+
+if test $punit -eq 1 || test $kunit -eq 1
+then exit 1
+else exit 0
+fi


### PR DESCRIPTION
When pushing code to remote with 'git push', the hook script (once copied into the hooks directory under .git) will run Python & kdb unit tests, stopping any code push to remote that causes any unit tests to fail.